### PR TITLE
chore: improve and refactor unit tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pytest
+from numpy.random import Generator
+from numpy.typing import NDArray
+
+from mabby.arms import Arm
+from mabby.bandits import Bandit
+
+
+class GenericBandit(Bandit):
+    def default_name(self) -> str:
+        return ""
+
+    def _prime(self, k: int, steps: int) -> None:
+        self.k = k
+
+    def _choose(self, rng: Generator) -> int:
+        return 0
+
+    def _update(self, choice: int, reward: float) -> None:
+        pass
+
+    def compute_Qs(self) -> NDArray[np.float64]:
+        return np.zeros(self.k)
+
+
+class GenericArm(Arm):
+    def __init__(self, **kwargs: float):
+        pass
+
+    def play(self, rng: Generator) -> float:
+        return 1
+
+    @property
+    def mean(self) -> float:
+        return 0
+
+
+@pytest.fixture
+def bandit_factory():
+    class GenericBanditFactory:
+        @staticmethod
+        def generic():
+            return GenericBandit()
+
+    return GenericBanditFactory
+
+
+@pytest.fixture
+def arm_factory():
+    class GenericArmFactory:
+        @staticmethod
+        def generic():
+            return GenericArm()
+
+    return GenericArmFactory

--- a/tests/unit/test_arms.py
+++ b/tests/unit/test_arms.py
@@ -5,7 +5,7 @@ from mabby.arms import Arm, ArmSet, BernoulliArm, GaussianArm
 
 @pytest.fixture()
 def mock_rng(mocker):
-    return mocker.MagicMock()
+    return mocker.Mock()
 
 
 class TestArm:
@@ -98,7 +98,7 @@ class TestGaussianArm(TestArm):
 class TestArmSet:
     @pytest.fixture(params=[[1, 3], [0.2, 0.7, 0.3]])
     def mock_arms(self, mocker, request):
-        return [mocker.MagicMock(mean=m) for m in request.param]
+        return [mocker.Mock(mean=m) for m in request.param]
 
     @pytest.fixture()
     def mock_armset(self, mock_arms):

--- a/tests/unit/test_bandits.py
+++ b/tests/unit/test_bandits.py
@@ -7,7 +7,7 @@ from mabby.exceptions import BanditUsageError
 
 @pytest.fixture
 def mock_rng(mocker):
-    return mocker.MagicMock(random=lambda: 0.5)
+    return mocker.Mock(random=lambda: 0.5)
 
 
 class TestBandit:
@@ -151,14 +151,14 @@ class TestEpsilonGreedyBandit(TestBandit):
     def test__choose_explores_with_low_rng(
         self, mocker, valid_params, prime_params, primed_bandit
     ):
-        mock_rng = mocker.MagicMock(random=lambda: 0.9 * valid_params["eps"])
+        mock_rng = mocker.Mock(random=lambda: 0.9 * valid_params["eps"])
         primed_bandit._choose(mock_rng)
         mock_rng.integers.assert_called_once_with(0, prime_params["k"])
 
     def test__choose_exploits_with_high_rng(
         self, mocker, valid_params, primed_bandit, Qs
     ):
-        mock_rng = mocker.MagicMock(random=lambda: 1.1 * valid_params["eps"])
+        mock_rng = mocker.Mock(random=lambda: 1.1 * valid_params["eps"])
         primed_bandit._Qs = Qs
         choice = primed_bandit._choose(mock_rng)
         assert Qs[choice] == max(Qs)


### PR DESCRIPTION
* use generic bandits and arms with scaffolded implementations instead of mocks
* replace `MagicMock` with `Mock` where extra functionality is not necessary
* replace call-checking unit tests for arms with general checks on distribution of samples 