### PR TITLE
chore: setup pytest-xdist for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test-unit: unit
 
 .PHONY: integration
 integration: $(INSTALL_STAMP) ## run all integration tests
-	$(POETRY) run pytest ./tests/integration/ $(NAME)
+	$(POETRY) run pytest -n auto ./tests/integration/ $(NAME)
 
 .PHONY: test-integration
 test-integration: integration

--- a/poetry.lock
+++ b/poetry.lock
@@ -290,6 +290,21 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "1.9.0"
+description = "execnet: rapid multi-Python deployment"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},
+    {file = "execnet-1.9.0.tar.gz", hash = "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5"},
+]
+
+[package.extras]
+testing = ["pre-commit"]
+
+[[package]]
 name = "filelock"
 version = "3.9.0"
 description = "A platform independent file lock."
@@ -1118,6 +1133,27 @@ importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""
 pytest = "*"
 
 [[package]]
+name = "pytest-xdist"
+version = "3.2.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-xdist-3.2.0.tar.gz", hash = "sha256:fa10f95a2564cd91652f2d132725183c3b590d9fdcdec09d3677386ecf4c1ce9"},
+    {file = "pytest_xdist-3.2.0-py3-none-any.whl", hash = "sha256:336098e3bbd8193276867cc87db8b22903c3927665dff9d1ac8684c02f597b68"},
+]
+
+[package.dependencies]
+execnet = ">=1.1"
+pytest = ">=6.2.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1392,4 +1428,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "93234bb3a20cb307071468ed2074bc78d858315c655df5752f49b8e898526f73"
+content-hash = "599e1eaf66cce77b5accd455f5b24f4cb80c79774dae0da431ff8d507f0aa298"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ pytest-cov = "^4.0.0"
 pytest-mock = "^3.10.0"
 pyproject-fmt = "^0.9.1"
 pytest-randomly = "^3.12.0"
+pytest-xdist = "^3.2.0"
 
 [tool.ruff]
 target-version = "py39"


### PR DESCRIPTION
Integration tests take a long time to run and can be parallelized with `pytest-xdist`.